### PR TITLE
examples: palettes example improved

### DIFF
--- a/examples/palettes/graphics/cavegirl_alt.json
+++ b/examples/palettes/graphics/cavegirl_alt.json
@@ -1,4 +1,3 @@
 {
-    "type": "sprite",
-	"height": 8
+    "type": "sprite_palette"
 }

--- a/examples/palettes/src/main.cpp
+++ b/examples/palettes/src/main.cpp
@@ -19,7 +19,7 @@
 
 #include "bn_sprite_items_cavegirl.h"
 #include "bn_regular_bg_items_village.h"
-#include "bn_sprite_items_cavegirl_alt.h"
+#include "bn_sprite_palette_items_cavegirl_alt.h"
 #include "bn_sprite_items_cavegirl_green.h"
 
 #include "info.h"
@@ -39,7 +39,7 @@ namespace
 
         bn::sprite_ptr cavegirl_sprite = bn::sprite_items::cavegirl.create_sprite(0, 0);
         const bn::sprite_palette_item& palette_item = bn::sprite_items::cavegirl.palette_item();
-        const bn::sprite_palette_item& alt_palette_item = bn::sprite_items::cavegirl_alt.palette_item();
+        const bn::sprite_palette_item& alt_palette_item = bn::sprite_palette_items::cavegirl_alt;
         bn::sprite_palette_ptr cavegirl_palette = cavegirl_sprite.palette();
         cavegirl_palette.set_colors(alt_palette_item);
 


### PR DESCRIPTION
It's little odd that the docs has a section deals with [Importing sprite_palettes](https://gvaliente.github.io/butano/import.html#import_sprite_palette), but the `palettes` example don't use this functionality, 
even though the `cavegirl_alt.bmp` only contains palette information.
So, I've changed `palettes` example to use this.