### PR TITLE
tools: s3m files now export instrument by default

### DIFF
--- a/butano/tools/butano_dmg_audio_tool.py
+++ b/butano/tools/butano_dmg_audio_tool.py
@@ -66,7 +66,7 @@ class DmgAudioFileInfo:
         sys.stdout = io.StringIO()
 
         try:
-            s3m2gbt.convert_file(self.__file_path, output_tag, output_file_path, False)
+            s3m2gbt.convert_file(self.__file_path, output_tag, output_file_path, True)
             sys.stdout = sys.__stdout__
         except Exception:
             sys.stdout = sys.__stdout__


### PR DESCRIPTION
You can [export custom waveform on `s3m2gbt`](https://github.com/GValiente/butano/tree/03f6edcf069d6462f7eb07c60dcc699b41802db9/butano/tools/s3m2gbt#samples).
> You are allowed to replace the samples of the channel 3. If the resulting sample is exactly 32 or 64 samples long, you can pass the --instruments flag to s3m2gbt and it will export all valid instruments along the patterns of your song. They will replace the default instruments of GBT Player for the duration of the song.

But looks like Butano doesn't provide any option to enable it.

This commit just defaults to always export channel 3 custom waveforms.