### PR TITLE
butano: generic_pool assert fixed

### DIFF
--- a/butano/include/bn_generic_pool.h
+++ b/butano/include/bn_generic_pool.h
@@ -273,6 +273,8 @@ public:
     template<typename Type, typename... Args>
     [[nodiscard]] Type& create(Args&&... args)
     {
+        static_assert(sizeof(Type) <= MaxElementSize);
+
         auto result = reinterpret_cast<Type*>(base_type::_allocate());
         ::new(result) Type(forward<Args>(args)...);
         return *result;
@@ -284,6 +286,7 @@ public:
     template<typename Type>
     void destroy(Type& value)
     {
+        static_assert(sizeof(Type) <= MaxElementSize);
         BN_BASIC_ASSERT(contains(value), "Pool does not contain this value");
 
         value.~Type();


### PR DESCRIPTION
There's no size check on `bn::generic_pool::create()` and `bn::generic_pool::destroy()`, which can result in UB like below.
This commit adds the size check.

```cpp
#include "bn_core.h"
#include "bn_generic_pool.h"
#include "bn_log.h"

int main() {
    bn::core::init();
    bn::generic_pool<1, 1> pool1;
    bn::generic_pool<1, 1> pool2;

    long long& ub1 = pool1.create<long long>(987654321);
    long long& ub2 = pool2.create<long long>(123456789);
    BN_LOG("ub1: ", ub1, "(", &ub1, ")");
    BN_LOG("ub2: ", ub2, "(", &ub2, ")");
    pool1.destroy(ub1);
    pool2.destroy(ub2);

    while (true)
        bn::core::update();
}
```

```cpp
[WARN] GBA Debug:  ub1: 987654321(0x3007dc4)
[WARN] GBA Debug:  ub2: 4193522457809505557(0x3007ddc)
```

![test-0](https://user-images.githubusercontent.com/34793045/220844085-52fe8280-db08-4c67-9c02-0587c74daeb2.png)