### PR TITLE
butano: optional::value_type alias added

### DIFF
--- a/butano/include/bn_optional.h
+++ b/butano/include/bn_optional.h
@@ -42,6 +42,8 @@ class optional
 {
 
 public:
+    using value_type = Type; //!< Value type alias.
+
     /**
      * @brief Default constructor.
      */


### PR DESCRIPTION
test code with `ninja` sprite
```cpp
#include <bn_core.h>
#include <bn_optional.h>
#include <bn_sprite_animate_actions.h>

#include "bn_sprite_items_ninja.h"

struct my_anim_sprite {
    bn::optional<bn::sprite_ptr> sprite;
    bn::optional<bn::sprite_animate_action<4>> animate_action;

    void create_anim_action() {
        sprite = bn::sprite_items::ninja.create_sprite(0, 0);
        // using bn::optional::value_type
        animate_action = decltype(animate_action)::value_type::forever(*sprite, 8, bn::sprite_items::ninja.tiles_item(),
                                                                       bn::array<const uint16_t,4>{0, 1, 2, 3});
    }
};

int main() {
    bn::core::init();
    my_anim_sprite anim_sprite;
    anim_sprite.create_anim_action();
    while (true) {
        anim_sprite.animate_action->update();
        bn::core::update();
    }
}
```