### PR TITLE
Make to_value_template_action base public on affine_bg_rotate_to_action

### DIFF
--- a/butano/include/bn_affine_bg_actions.h
+++ b/butano/include/bn_affine_bg_actions.h
@@ -550,7 +550,7 @@ public:
  * @ingroup action
  */
 class affine_bg_rotate_to_action :
-        to_value_template_action<affine_bg_ptr, fixed, affine_bg_rotation_manager>
+        public to_value_template_action<affine_bg_ptr, fixed, affine_bg_rotation_manager>
 {
 
 public:


### PR DESCRIPTION
I had to do this recently in order to use `done()` and `update()` on a `affine_bg_rotate_to_action`:

```
src/ending_scene.cpp:124:35: error: 'bn::to_value_template_action<bn::affine_bg_ptr, bn::fixed_t<12>, bn::affine_bg_rotation_manager>' is not an accessible base of 'bn::affine_bg_rotate_to_action'
  124 |         while (!rotate_planet.done()) {
      |                 ~~~~~~~~~~~~~~~~~~^~
src/ending_scene.cpp:125:33: error: 'void bn::to_value_template_action<Value, Property, PropertyManager>::update() [with Value = bn::affine_bg_ptr; Property = bn::fixed_t<12>; PropertyManager = bn::affine_bg_rotation_manager]' is inaccessible within this context
  125 |             rotate_planet.update();```