### PR TITLE
Method to set seed to random generator

### DIFF
--- a/butano/include/bn_random.h
+++ b/butano/include/bn_random.h
@@ -149,13 +149,13 @@ public:
 
     /** @brief Sets the current state of the random number generator.
      * @note In combination with get_state(), this can be used to save and restore the state of the random number.
-     * @param state State to set.
+     * @param newstate State to set.
      */
-    constexpr void set_state(const state& state)
+    constexpr void set_state(const state& newstate)
     {
-        _x = state.x;
-        _y = state.y;
-        _z = state.z;
+        _x = newstate.x;
+        _y = newstate.y;
+        _z = newstate.z;
     }
 
     /**

--- a/butano/include/bn_random.h
+++ b/butano/include/bn_random.h
@@ -31,8 +31,16 @@ namespace bn
  */
 class random
 {
-
 public:
+
+    /// @brief stores the internal state of the random number generator.
+    struct state
+    {
+        unsigned x;
+        unsigned y;
+        unsigned z;
+    };
+
     /**
      * @brief Returns a random unsigned integer greater or equal than 0,
      * modifying its internal seed in the process.
@@ -128,6 +136,26 @@ public:
     constexpr void set_seed(unsigned seed){
         BN_ASSERT(seed != 0, "Invalid seed (must be grater than zero): ", seed);
         _x = seed;
+    }
+
+    /** @brief Returns the current state of the random number generator.
+     * @note In combination with set_state(), this can be used to save and restore the state of the random number.
+     * @return Current state of the random number generator.
+     */
+    [[nodiscard]] constexpr state get_state() const
+    {
+        return { _x, _y, _z };
+    }
+
+    /** @brief Sets the current state of the random number generator.
+     * @note In combination with get_state(), this can be used to save and restore the state of the random number.
+     * @param state State to set.
+     */
+    constexpr void set_state(const state& state)
+    {
+        _x = state.x;
+        _y = state.y;
+        _z = state.z;
     }
 
     /**

--- a/butano/include/bn_random.h
+++ b/butano/include/bn_random.h
@@ -131,13 +131,6 @@ public:
         return minimum + fixed::from_data(int(result));
     }
 
-    /// @brief Sets the current seed position.
-    /// @param seed non-zero value to set the current seed position.
-    constexpr void set_seed(unsigned seed){
-        BN_ASSERT(seed != 0, "Invalid seed (must be grater than zero): ", seed);
-        _x = seed;
-    }
-
     /** @brief Returns the current state of the random number generator.
      * @note In combination with set_state(), this can be used to save and restore the state of the random number.
      * @return Current state of the random number generator.

--- a/butano/include/bn_random.h
+++ b/butano/include/bn_random.h
@@ -123,6 +123,13 @@ public:
         return minimum + fixed::from_data(int(result));
     }
 
+    /// @brief Sets the current seed position.
+    /// @param seed non-zero value to set the current seed position.
+    constexpr void set_seed(unsigned seed){
+        BN_ASSERT(seed != 0, "Invalid seed (must be grater than zero): ", seed);
+        _x = seed;
+    }
+
     /**
      * @brief Updates the value of the internal seed.
      */


### PR DESCRIPTION
Adding the method set_seed() to the BN::random class

This allows setting the current position of the internal _x value which allows to use of the deterministic random generator in a somehow less deterministic way.

It asserts to a nonzero value to ensure not breaking the shifter.