### PR TITLE
add methods to check if rectangle contains another one (entirely)

### DIFF
--- a/butano/include/bn_fixed_rect.h
+++ b/butano/include/bn_fixed_rect.h
@@ -291,6 +291,28 @@ public:
     }
 
     /**
+     * @brief Indicates if this rectangle contains the given one entirely.
+     *
+     * A rectangle is considered to contain another rectangle entirely if all four corners of
+     * the specified rectangle are within the boundaries of this rectangle.
+     *
+     */
+    [[nodiscard]] constexpr bool contains(const fixed_rect_t& other) const
+    {
+        fixed_t<Precision> this_left = left();
+        fixed_t<Precision> other_left = other.left();
+
+        if (this_left <= other_left && this_left + width() >= other_left + other.width())
+        {
+            fixed_t<Precision> this_top = top();
+            fixed_t<Precision> other_top = other.top();
+            return this_top <= other_top && this_top + height() >= other_top + other.height();
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Indicates if this rectangle intersects with the given one or not.
      *
      * Two rectangles intersect if there is at least one point that is within both rectangles.

--- a/butano/include/bn_rect.h
+++ b/butano/include/bn_rect.h
@@ -306,6 +306,28 @@ public:
     }
 
     /**
+     * @brief Indicates if this rectangle contains the given one entirely.
+     *
+     * A rectangle is considered to contain another rectangle entirely if all four corners of
+     * the specified rectangle are within the boundaries of this rectangle.
+     *
+     */
+    [[nodiscard]] constexpr bool contains(const rect& other) const
+    {
+        int this_left = left();
+        int other_left = other.left();
+
+        if (this_left <= other_left && this_left + width() >= other_left + other.width())
+        {
+            int this_top = top();
+            int other_top = other.top();
+            return this_top <= other_top && this_top + height() >= other_top + other.height();
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Multiplies both width and height of the rectangle by the given factor.
      * @param value Integer multiplication factor.
      * @return Reference to this.

--- a/butano/include/bn_top_left_fixed_rect.h
+++ b/butano/include/bn_top_left_fixed_rect.h
@@ -278,7 +278,7 @@ public:
      *
      * If the point is in the edge of the rectangle, it returns `false`.
      */
-    [[nodiscard]] constexpr bool contains(const fixed_point_t<Precision>& point) const
+    [[nodiscard]] constexpr bool contains(const top_left_fixed_point_t<Precision>& point) const
     {
         fixed_t<Precision> this_left = left();
 

--- a/butano/include/bn_top_left_fixed_rect.h
+++ b/butano/include/bn_top_left_fixed_rect.h
@@ -278,7 +278,7 @@ public:
      *
      * If the point is in the edge of the rectangle, it returns `false`.
      */
-    [[nodiscard]] constexpr bool contains(const top_left_fixed_point_t<Precision>& point) const
+    [[nodiscard]] constexpr bool contains(const fixed_point_t<Precision>& point) const
     {
         fixed_t<Precision> this_left = left();
 

--- a/butano/include/bn_top_left_fixed_rect.h
+++ b/butano/include/bn_top_left_fixed_rect.h
@@ -312,6 +312,28 @@ public:
     }
 
     /**
+     * @brief Indicates if this rectangle contains the given one entirely.
+     *
+     * A rectangle is considered to contain another rectangle entirely if all four corners of
+     * the specified rectangle are within the boundaries of this rectangle.
+     *
+     */
+    [[nodiscard]] constexpr bool contains(const fixed_rect_t& other) const
+    {
+        fixed_t<Precision> this_left = left();
+        fixed_t<Precision> other_left = other.left();
+
+        if (this_left <= other_left && this_left + width() >= other_left + other.width())
+        {
+            fixed_t<Precision> this_top = top();
+            fixed_t<Precision> other_top = other.top();
+            return this_top <= other_top && this_top + height() >= other_top + other.height();
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Default equal operator.
      */
     [[nodiscard]] constexpr friend bool operator==(

--- a/butano/include/bn_top_left_fixed_rect.h
+++ b/butano/include/bn_top_left_fixed_rect.h
@@ -318,7 +318,7 @@ public:
      * the specified rectangle are within the boundaries of this rectangle.
      *
      */
-    [[nodiscard]] constexpr bool contains(const fixed_rect_t& other) const
+    [[nodiscard]] constexpr bool contains(const top_left_fixed_rect_t& other) const
     {
         fixed_t<Precision> this_left = left();
         fixed_t<Precision> other_left = other.left();

--- a/butano/include/bn_top_left_rect.h
+++ b/butano/include/bn_top_left_rect.h
@@ -308,7 +308,7 @@ public:
      * the specified rectangle are within the boundaries of this rectangle.
      *
      */
-    [[nodiscard]] constexpr bool contains(const rect& other) const
+    [[nodiscard]] constexpr bool contains(const top_left_rect& other) const
     {
         int this_left = left();
         int other_left = other.left();

--- a/butano/include/bn_top_left_rect.h
+++ b/butano/include/bn_top_left_rect.h
@@ -302,6 +302,28 @@ public:
     }
 
     /**
+     * @brief Indicates if this rectangle contains the given one entirely.
+     *
+     * A rectangle is considered to contain another rectangle entirely if all four corners of
+     * the specified rectangle are within the boundaries of this rectangle.
+     *
+     */
+    [[nodiscard]] constexpr bool contains(const rect& other) const
+    {
+        int this_left = left();
+        int other_left = other.left();
+
+        if (this_left <= other_left && this_left + width() >= other_left + other.width())
+        {
+            int this_top = top();
+            int other_top = other.top();
+            return this_top <= other_top && this_top + height() >= other_top + other.height();
+        }
+
+        return false;
+    }
+
+    /**
      * @brief Default equal operator.
      */
     [[nodiscard]] constexpr friend bool operator==(const top_left_rect& a, const top_left_rect& b) = default;


### PR DESCRIPTION
This method is particularly useful when the second rectangle has a surface area less than or equal to the first, to determine whether it is completely inside the first rectangle.
Ex : I use it for an 8-way collision box to know when it has fully entered another one