### PR TITLE
butano: deque::erase fixed

### DIFF
--- a/butano/include/bn_deque.h
+++ b/butano/include/bn_deque.h
@@ -980,7 +980,7 @@ public:
         BN_ASSERT(first_index >= 0 && first_index < size, "Invalid first: ", first_index, " - ", size);
 
         size_type last_index = last._index;
-        BN_ASSERT(last_index >= 0 && last_index < size, "Invalid last: ", last_index, " - ", size);
+        BN_ASSERT(last_index >= 0 && last_index <= size, "Invalid last: ", last_index, " - ", size);
 
         size_type delete_count = last_index - first_index;
         BN_ASSERT(delete_count >= 0 && delete_count <= size, "Invalid delete count: ", delete_count, " - ", size);


### PR DESCRIPTION
# Issue

`bn::deque::erase(first, last)` can't receive `end()` iterator as an argument for `last`.

# Reproduce

## Code
```cpp
#include <bn_core.h>
#include <bn_deque.h>
#include <bn_log.h>

int main() {
    bn::core::init();

    bn::deque<int, 8> dq;
    dq.push_back(5);
    dq.push_back(6);
    dq.push_back(7);

    dq.erase(++dq.begin(), dq.end());

    for (int elem : dq)
        BN_LOG(elem);

    while (true)
        bn::core::update();
}
```

## Result
![test2-0](https://github.com/user-attachments/assets/b934f620-0d47-41b8-b69b-8f25fc57e3fa)
