### PR TITLE
butano: advgm updated to 0.3.0

### DIFF
--- a/butano/hw/3rd_party/advgm/include/advgm_hardware.h
+++ b/butano/hw/3rd_party/advgm/include/advgm_hardware.h
@@ -21,8 +21,8 @@
 #define ADVGM_EWRAM_DATA __attribute__((section(".ewram_data")))
 #define ADVGM_EWRAM_CODE __attribute__((section(".ewram_code"), long_call))
 
-// Registers
-// ---------------
+// I/O Registers Definitions
+// =========================
 
 #define ADVGM_MEM_IO_ADDR (0x04000000)
 #define ADVGM_MEM_IO ((void*)ADVGM_MEM_IO_ADDR)
@@ -35,6 +35,9 @@
 #define ADVGM_PTR_REG_16(r) ((volatile uint16_t*)(ADVGM_MEM_IO_ADDR + (r)))
 #define ADVGM_PTR_REG_32(r) ((volatile uint32_t*)(ADVGM_MEM_IO_ADDR + (r)))
 
+//------------------------------------------
+
+// Sound Registers
 #define ADVGM_OFFSET_SND1SWEEP (0x060) // R/W
 #define ADVGM_OFFSET_SND1CNT (0x062)   // R/W
 #define ADVGM_OFFSET_SND1FREQ (0x064)  // R/W
@@ -63,6 +66,23 @@
 #define ADVGM_OFFSET_WAVE_RAM3 (0x09C)   // R/W
 #define ADVGM_OFFSET_WAVE_RAM3_L (0x09C) // R/W
 #define ADVGM_OFFSET_WAVE_RAM3_H (0x09E) // R/W
+
+// Timer Registers
+#define ADVGM_OFFSET_TM0D (0x100)   // R/W
+#define ADVGM_OFFSET_TM0CNT (0x102) // R/W
+#define ADVGM_OFFSET_TM1D (0x104)   // R/W
+#define ADVGM_OFFSET_TM1CNT (0x106) // R/W
+#define ADVGM_OFFSET_TM2D (0x108)   // R/W
+#define ADVGM_OFFSET_TM2CNT (0x10A) // R/W
+#define ADVGM_OFFSET_TM3D (0x10C)   // R/W
+#define ADVGM_OFFSET_TM3CNT (0x10E) // R/W
+
+// Interrupt Control
+#define ADVGM_OFFSET_IE (0x200)  // R/W
+#define ADVGM_OFFSET_IF (0x202)  // R/W
+#define ADVGM_OFFSET_IME (0x208) // R/W
+
+//------------------------------------------
 
 #define ADVGM_REG_SND1SWEEP ADVGM_REG_16(ADVGM_OFFSET_SND1SWEEP) // Sound 1 Sweep control
 #define ADVGM_REG_SND1CNT ADVGM_REG_16(ADVGM_OFFSET_SND1CNT)     // Sound 1 Length, wave duty and envelope control
@@ -93,7 +113,23 @@
 #define ADVGM_REG_WAVE_RAM3_L ADVGM_REG_16(ADVGM_OFFSET_WAVE_RAM3_L) // Sound 3 samples 24-27
 #define ADVGM_REG_WAVE_RAM3_H ADVGM_REG_16(ADVGM_OFFSET_WAVE_RAM3_H) // Sound 3 samples 28-31
 
-// Register values
+#define ADVGM_REG_TM0D ADVGM_REG_16(ADVGM_OFFSET_TM0D)     // Timer 0 data
+#define ADVGM_REG_TM0CNT ADVGM_REG_16(ADVGM_OFFSET_TM0CNT) // Timer 0 control
+#define ADVGM_REG_TM1D ADVGM_REG_16(ADVGM_OFFSET_TM1D)     // Timer 1 data
+#define ADVGM_REG_TM1CNT ADVGM_REG_16(ADVGM_OFFSET_TM1CNT) // Timer 1 control
+#define ADVGM_REG_TM2D ADVGM_REG_16(ADVGM_OFFSET_TM2D)     // Timer 2 data
+#define ADVGM_REG_TM2CNT ADVGM_REG_16(ADVGM_OFFSET_TM2CNT) // Timer 2 control
+#define ADVGM_REG_TM3D ADVGM_REG_16(ADVGM_OFFSET_TM3D)     // Timer 3 data
+#define ADVGM_REG_TM3CNT ADVGM_REG_16(ADVGM_OFFSET_TM3CNT) // Timer 3 control
+
+#define ADVGM_REG_IE ADVGM_REG_16(ADVGM_OFFSET_IE)   // Interrupt Enable
+#define ADVGM_REG_IF ADVGM_REG_16(ADVGM_OFFSET_IF)   // Interrupt Fired
+#define ADVGM_REG_IME ADVGM_REG_16(ADVGM_OFFSET_IME) // Interrupt Master Enable
+
+// Per-register fields definitions
+// ===============================
+
+// Sound Registers
 // ---------------
 
 // SND1SWEEP (NR10) (SOUND1CNT_L)
@@ -292,5 +328,49 @@
 #define ADVGM_SNDBIAS_SAMPLE_RATE_65KHZ (1 << 14)
 #define ADVGM_SNDBIAS_SAMPLE_RATE_131KHZ (2 << 14)
 #define ADVGM_SNDBIAS_SAMPLE_RATE_262KHZ (3 << 14) // Best for PSG channels 1-4
+
+// Timer Registers
+// ---------------
+
+// TM0CNT, TM1CNT, TM2CNT, TM3CNT
+
+#define ADVGM_TMxCNT_PRESCALER_F_DIV_1 (0 << 0)
+#define ADVGM_TMxCNT_PRESCALER_F_DIV_64 (1 << 0)
+#define ADVGM_TMxCNT_PRESCALER_F_DIV_256 (2 << 0)
+#define ADVGM_TMxCNT_PRESCALER_F_DIV_1024 (3 << 0)
+
+#define ADVGM_TMxCNT_STANDALONE (0 << 2)
+#define ADVGM_TMxCNT_CASCADE (1 << 2) // Not used in TM0CNT
+
+#define ADVGM_TMxCNT_IRQ_DISABLE (0 << 6)
+#define ADVGM_TMxCNT_IRQ_ENABLE (1 << 6)
+
+#define ADVGM_TMxCNT_STOP (0 << 7)
+#define ADVGM_TMxCNT_START (1 << 7)
+
+// Interrupt Control
+// -----------------
+
+// IE, IF
+
+#define ADVGM_IRQF_VBLANK (1 << 0)
+#define ADVGM_IRQF_HBLANK (1 << 1)
+#define ADVGM_IRQF_VCOUNT (1 << 2)
+#define ADVGM_IRQF_TIMER0 (1 << 3)
+#define ADVGM_IRQF_TIMER1 (1 << 4)
+#define ADVGM_IRQF_TIMER2 (1 << 5)
+#define ADVGM_IRQF_TIMER3 (1 << 6)
+#define ADVGM_IRQF_SERIAL (1 << 7)
+#define ADVGM_IRQF_DMA0 (1 << 8)
+#define ADVGM_IRQF_DMA1 (1 << 9)
+#define ADVGM_IRQF_DMA2 (1 << 10)
+#define ADVGM_IRQF_DMA3 (1 << 11)
+#define ADVGM_IRQF_KEYPAD (1 << 12)
+#define ADVGM_IRQF_GAMEPAK (1 << 13)
+
+// IME
+
+#define ADVGM_IME_DISABLE (0 << 0)
+#define ADVGM_IME_ENABLE (1 << 0)
 
 #endif // ADVGM_HARDWARE_H

--- a/butano/hw/3rd_party/advgm/src/advgm.c
+++ b/butano/hw/3rd_party/advgm/src/advgm.c
@@ -4,15 +4,16 @@
 
 #include "../include/advgm.h"
 
-#include "advgm_hardware.h"
+#include "../include/advgm_hardware.h"
 
 #include <stddef.h>
 
 enum advgm_music_cmd_t
 {
-    ADVGM_MUSIC_CMD_WAIT_FOR_VBLANK = 0x61,
-    ADVGM_MUSIC_CMD_END_MARK = 0x66,
-    ADVGM_MUSIC_CMD_WRITE_REG = 0xB3,
+    ADVGM_MUSIC_CMD_END_MARK = 0x00,
+    ADVGM_MUSIC_CMD_WAIT_FOR_VBLANK = 0x01,
+
+    // Write to registers at command offset for [0x60..0x9F]
 };
 
 typedef struct advgm_player_t
@@ -50,15 +51,39 @@ bool advgm_update(void)
 
     for (;;)
     {
-        uint8_t command = *player.next_fetch_pos++;
+        const uint8_t command = *player.next_fetch_pos++;
 
         switch (command)
         {
         case ADVGM_MUSIC_CMD_WAIT_FOR_VBLANK:
             return true;
 
-        case ADVGM_MUSIC_CMD_WRITE_REG: {
-            const uint8_t offset = *player.next_fetch_pos++;
+        case ADVGM_MUSIC_CMD_END_MARK: {
+            if (!player.loop)
+            {
+                advgm_stop();
+                return true;
+            }
+
+            uint32_t loop_pos = *player.next_fetch_pos++;
+            loop_pos |= *player.next_fetch_pos++ << 8;
+            loop_pos |= *player.next_fetch_pos++ << 16;
+            loop_pos |= *player.next_fetch_pos++ << 24;
+
+            player.next_fetch_pos = player.music + loop_pos;
+            continue;
+        }
+
+        // Write to register at command offset for [0x60..0x9F]
+        default: {
+            const uint8_t offset = command;
+
+            if (offset < ADVGM_OFFSET_SND1SWEEP || offset > ADVGM_OFFSET_WAVE_RAM3_H + 1)
+            {
+                advgm_stop();
+                return false;
+            }
+
             uint8_t data = *player.next_fetch_pos++;
 
             // Ignore Ch3 bank switching done by music commands
@@ -84,25 +109,6 @@ bool advgm_update(void)
 
             continue;
         }
-
-        case ADVGM_MUSIC_CMD_END_MARK: {
-            if (!player.loop)
-            {
-                advgm_stop();
-                return true;
-            }
-
-            uint32_t loop_pos = *player.next_fetch_pos++;
-            loop_pos |= *player.next_fetch_pos++ << 8;
-            loop_pos |= *player.next_fetch_pos++ << 16;
-            loop_pos |= *player.next_fetch_pos++ << 24;
-
-            player.next_fetch_pos = player.music + loop_pos;
-            continue;
-        }
-
-        default:
-            return false;
         }
     }
 }

--- a/butano/tools/advgm/advgm_converter.py
+++ b/butano/tools/advgm/advgm_converter.py
@@ -31,7 +31,7 @@ class VgmFile:
         # convert reg
         p = 0x34 + int.from_bytes(data[0x34:0x38], byteorder="little")
         while data[p] != 0x66:  # end of mark
-            # wait: 0x61 nn nn
+            # wait: 0x62
             if data[p] == 0x61:
                 p += 3
                 continue
@@ -155,12 +155,12 @@ class VgmFile:
                 loop_bin = fputc_cnt
                 is_loop = True
 
-            # wait: 0x61 nn nn
+            # wait: 0x62
             if 0x61 <= data[p] <= 0x63 or 0x70 <= data[p] <= 0x7F:
                 # GBA side use vblank
-                converted += b"\x61"
+                converted += b"\x01"
                 fputc_cnt += 1
-                # ignore param
+                # ignore param: 0x61 nn nn
                 if data[p] == 0x61:
                     p += 3
                 else:
@@ -169,9 +169,9 @@ class VgmFile:
 
             # write reg: 0xb3 aa dd
             if data[p] == 0xB3:
-                converted += data[p : p + 3]
+                converted += data[p + 1 : p + 3]
                 p += 3
-                fputc_cnt += 3
+                fputc_cnt += 2
 
                 continue
 
@@ -180,17 +180,12 @@ class VgmFile:
         if not is_loop:
             print("Warning: loop offset not found")
 
-        # write end of mark
-        converted += data[p].to_bytes(1, byteorder="little")
+        # write end mark
+        converted += b"\x00"
         p += 1
 
         # write loop offset
         converted += loop_bin.to_bytes(4, byteorder="little")
-
-        # zero padding
-        pad = len(converted) & 0xF
-        if pad != 0:
-            converted += b"\x00" * (0x10 - pad)
 
         return converted
 


### PR DESCRIPTION
* **(Sort of breaking change)** Optimize vgm data encoding.
   * Now it uses up to 33% less ROM for converted musics.
   * Because of encoding changes, **all musics need to be reconverted** with `advgm_converter.py` (Sorry!)
      * i.e. Users would need to do a clean build (a.k.a. `make clean` and `make -j8`) for their project.
* Automatically stops playback on error.
* Other misc changes that's irrelevant for butano:
   * Move `advgm_hardware.h` to public header directory `include/`
   * Add more register definitions in `advgm_hardware.h`