### PR TITLE
butano: build warning fixed for c++26

### DIFF
--- a/butano/include/bn_memory.h
+++ b/butano/include/bn_memory.h
@@ -227,7 +227,7 @@ namespace bn::memory
     template<typename Type>
     void clear(int elements, Type& destination_ref)
     {
-        static_assert(is_trivial<Type>(), "Type is not trivial");
+        static_assert(is_trivially_default_constructible_v<Type> && is_trivially_copyable_v<Type>, "Type is not trivial");
         BN_ASSERT(elements >= 0, "Invalid elements: ", elements);
 
         if constexpr(sizeof(Type) == 4)

--- a/butano/include/bn_type_traits.h
+++ b/butano/include/bn_type_traits.h
@@ -24,8 +24,8 @@ namespace bn
     using std::is_same;
     using std::is_same_v;
 
-    using std::is_trivial;
-    using std::is_trivial_v;
+    using std::is_trivially_default_constructible;
+    using std::is_trivially_default_constructible_v;
 
     using std::is_trivially_copyable;
     using std::is_trivially_copyable_v;


### PR DESCRIPTION
```cpp
butano/butano/include/bn_memory.h: In function 'void bn::memory::clear(int, Type&)':
butano/butano/include/bn_memory.h:230:23: warning: 'template<class _Tp> struct std::is_trivial' is deprecated: use 'is_trivially_default_constructible && is_trivially_copyable' instead [-Wdeprecated-declarations]
  230 |         static_assert(is_trivial<Type>(), "Type is not trivial");
      |                       ^~~~~~~~~~
In file included from C:/msys64/opt/wonderful/toolchain/gcc-arm-none-eabi/arm-none-eabi/include/c++/16.1.1/bits/cpp_type_traits.h:42,
                 from C:/msys64/opt/wonderful/toolchain/gcc-arm-none-eabi/arm-none-eabi/include/c++/16.1.1/bits/stl_algobase.h:60,
                 from C:/msys64/opt/wonderful/toolchain/gcc-arm-none-eabi/arm-none-eabi/include/c++/16.1.1/algorithm:62,
                 from butano/butano/include/bn_algorithm.h:16,
                 from butano/butano/include/bn_istring_base.h:16,
                 from butano/butano/include/bn_assert.h:133,
                 from butano/butano/include/bn_array.h:16,
                 from butano/butano/include/bn_span.h:16,
                 from butano/butano/include/bn_core.h:16,
                 from butano/games/varooom-3d/src/main.cpp:6:
C:/msys64/opt/wonderful/toolchain/gcc-arm-none-eabi/arm-none-eabi/include/c++/16.1.1/type_traits:964:5: note: declared here
  964 |     is_trivial
      |     ^~~~~~~~~~
```